### PR TITLE
Add support for clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This exporter run `crm_mon -X`, and parse its XML output.
 | resources        | implemented     | enabled |
 | resources/bundle | not implemented |         |
 | resources/group  | implemented     | enabled |
-| resources/clone  | not implemented |         |
+| resources/clone  | implemented     | enabled |
 | tickets          | not implemented |         |
 | bans             | implemented     | enabled |
 | failures         | implemented     | enabled |

--- a/collector/crm_mon.go
+++ b/collector/crm_mon.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	crmMonElemEnabled = kingpin.Flag("collector.crm_mon.elements-enabled", "Pacemaker `crm_mon` XML elements that will be exported.").Default("summary,nodes,node_attributes,resources,resources_group,failures,bans").String()
+	crmMonElemEnabled = kingpin.Flag("collector.crm_mon.elements-enabled", "Pacemaker `crm_mon` XML elements that will be exported.").Default("summary,nodes,node_attributes,clones,resources,resources_group,failures,bans").String()
 )
 
 type crmMonCollector struct {
@@ -64,6 +64,16 @@ type crmMonCollector struct {
 	crmMonResourceGroupManaged        *prometheus.Desc
 	crmMonResourceGroupFailed         *prometheus.Desc
 	crmMonResourceGroupFailureIgnored *prometheus.Desc
+	crmMonResourceCloneMultistate     *prometheus.Desc
+	crmMonResourceClonePromoted       *prometheus.Desc
+	crmMonResourceCloneActive         *prometheus.Desc
+	crmMonResourceCloneOrphaned       *prometheus.Desc
+	crmMonResourceCloneBlocked        *prometheus.Desc
+	crmMonResourceCloneManaged        *prometheus.Desc
+	crmMonResourceCloneFailed         *prometheus.Desc
+	crmMonResourceCloneFailureIgnored *prometheus.Desc
+	crmMonResourceCloneNumActive      *prometheus.Desc
+	crmMonResourceCloneNumPromoted    *prometheus.Desc
 	crmMonFailuresCount               *prometheus.Desc
 	crmMonFailureDescription          *prometheus.Desc
 	crmMonBansCount                   *prometheus.Desc
@@ -267,6 +277,57 @@ func NewCrmMonCollector() (Collector, error) {
 			"Resource failure ignored.",
 			[]string{"id", "group", "node_name", "resource_agent", "role", "target_role"}, nil,
 		),
+
+		// Node Resources Clone metrics
+		crmMonResourceCloneMultistate: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "clone", "resource_multistate"),
+			"Resource is a multi-state one.",
+			[]string{"clone_id"}, nil,
+		),
+		crmMonResourceCloneNumActive: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "clone", "num_active"),
+			"Number of running clone instances",
+			[]string{"clone_id"}, nil,
+		),
+		crmMonResourceCloneNumPromoted: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "clone", "num_promoted"),
+			"Number of promoted clone instances",
+			[]string{"clone_id"}, nil,
+		),
+		crmMonResourceClonePromoted: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "clone", "resource_promoted"),
+			"Resource is promoted.",
+			[]string{"id", "clone_id", "node_name", "resource_agent", "role", "target_role"}, nil,
+		),
+		crmMonResourceCloneActive: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "clone", "resource_active"),
+			"Resource is active.",
+			[]string{"id", "clone_id", "node_name", "resource_agent", "role", "target_role"}, nil,
+		),
+		crmMonResourceCloneOrphaned: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "clone", "resource_orphaned"),
+			"Resource is orphaned.",
+			[]string{"id", "clone_id", "node_name", "resource_agent", "role", "target_role"}, nil,
+		),
+		crmMonResourceCloneBlocked: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "clone", "resource_blocked"),
+			"Resource is blocked.",
+			[]string{"id", "clone_id", "node_name", "resource_agent", "role", "target_role"}, nil,
+		),
+		crmMonResourceCloneManaged: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "clone", "resource_managed"),
+			"Resource is managed.",
+			[]string{"id", "clone_id", "node_name", "resource_agent", "role", "target_role"}, nil,
+		),
+		crmMonResourceCloneFailed: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "clone", "resource_failed"),
+			"Resource is failed.",
+			[]string{"id", "clone_id", "node_name", "resource_agent", "role", "target_role"}, nil,
+		),
+		crmMonResourceCloneFailureIgnored: prometheus.NewDesc(
+			prometheus.BuildFQName(namespace, "clone", "resource_failure_ignored"),
+			"Resource failure ignored.",
+			[]string{"id", "clone_id", "node_name", "resource_agent", "role", "target_role"}, nil,
 		),
 
 		// Failures metrics

--- a/collector/crm_mon.go
+++ b/collector/crm_mon.go
@@ -57,7 +57,6 @@ type crmMonCollector struct {
 	crmMonResourceManaged             *prometheus.Desc
 	crmMonResourceFailed              *prometheus.Desc
 	crmMonResourceFailureIgnored      *prometheus.Desc
-	crmMonResourceRunningOn           *prometheus.Desc
 	crmMonResourcesGroup              *prometheus.Desc
 	crmMonResourceGroupActive         *prometheus.Desc
 	crmMonResourceGroupOrphaned       *prometheus.Desc
@@ -65,7 +64,6 @@ type crmMonCollector struct {
 	crmMonResourceGroupManaged        *prometheus.Desc
 	crmMonResourceGroupFailed         *prometheus.Desc
 	crmMonResourceGroupFailureIgnored *prometheus.Desc
-	crmMonResourceGroupRunningOn      *prometheus.Desc
 	crmMonFailuresCount               *prometheus.Desc
 	crmMonFailureDescription          *prometheus.Desc
 	crmMonBansCount                   *prometheus.Desc
@@ -232,11 +230,6 @@ func NewCrmMonCollector() (Collector, error) {
 			"Resource failure ignored.",
 			[]string{"id", "node_name", "resource_agent", "role", "target_role"}, nil,
 		),
-		crmMonResourceRunningOn: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "resource", "nodes_running_on"),
-			"Number of nodes the resource is running on.",
-			[]string{"id", "resource_agent", "role", "target_role"}, nil,
-		),
 
 		// Node Resources Group metrics
 		crmMonResourcesGroup: prometheus.NewDesc(
@@ -274,10 +267,6 @@ func NewCrmMonCollector() (Collector, error) {
 			"Resource failure ignored.",
 			[]string{"id", "group", "node_name", "resource_agent", "role", "target_role"}, nil,
 		),
-		crmMonResourceGroupRunningOn: prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "group", "resource_nodes_running_on"),
-			"Number of nodes the resource is running on.",
-			[]string{"id", "group", "resource_agent", "role", "target_role"}, nil,
 		),
 
 		// Failures metrics

--- a/collector/crm_mon_linux.go
+++ b/collector/crm_mon_linux.go
@@ -346,66 +346,66 @@ func (c *crmMonCollector) exposeNodeAttributes(ch chan<- prometheus.Metric, node
 
 // expose Resources metrics
 func (c *crmMonCollector) exposeResources(ch chan<- prometheus.Metric, resourcesStruct ResourcesStruct) error {
-	for _, node := range resourcesStruct.Resource {
-		for _, nodeName := range node.Node {
-			if node.Active {
+	for _, resource := range resourcesStruct.Resource {
+		for _, nodeName := range resource.Node {
+			if resource.Active {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceActive,
-					prometheus.GaugeValue, 1.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 1.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			} else {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceActive,
-					prometheus.GaugeValue, 0.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 0.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			}
-			if node.Orphaned {
+			if resource.Orphaned {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceOrphaned,
-					prometheus.GaugeValue, 1.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 1.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			} else {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceOrphaned,
-					prometheus.GaugeValue, 0.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 0.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			}
-			if node.Blocked {
+			if resource.Blocked {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceBlocked,
-					prometheus.GaugeValue, 1.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 1.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			} else {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceBlocked,
-					prometheus.GaugeValue, 0.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 0.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			}
-			if node.Managed {
+			if resource.Managed {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceManaged,
-					prometheus.GaugeValue, 1.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 1.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			} else {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceManaged,
-					prometheus.GaugeValue, 0.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 0.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			}
-			if node.Failed {
+			if resource.Failed {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceFailed,
-					prometheus.GaugeValue, 1.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 1.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			} else {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceFailed,
-					prometheus.GaugeValue, 0.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 0.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			}
-			if node.FailureIgnored {
+			if resource.FailureIgnored {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceFailureIgnored,
-					prometheus.GaugeValue, 1.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 1.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			} else {
 				ch <- prometheus.MustNewConstMetric(c.crmMonResourceFailureIgnored,
-					prometheus.GaugeValue, 0.0, node.ID, nodeName.Name,
-					node.ResourceAgent, node.Role, node.TargetRole)
+					prometheus.GaugeValue, 0.0, resource.ID, nodeName.Name,
+					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			}
 		}
 		ch <- prometheus.MustNewConstMetric(c.crmMonResourceRunningOn,
-			prometheus.GaugeValue, node.NodesRunningOn, node.ID,
-			node.ResourceAgent, node.Role, node.TargetRole)
+                       prometheus.GaugeValue, resource.NodesRunningOn, resource.ID,
+                       resource.ResourceAgent, resource.Role, resource.TargetRole)
 	}
 	return nil
 }
@@ -415,78 +415,78 @@ func (c *crmMonCollector) exposeResourcesGroup(ch chan<- prometheus.Metric, reso
 	for _, group := range resourcesStruct.Group {
 		ch <- prometheus.MustNewConstMetric(c.crmMonResourcesGroup,
 			prometheus.GaugeValue, group.NumberResources, group.ID)
-		for _, node := range group.Resource {
-			for _, nodeName := range node.Node {
-				if node.Active {
+		for _, resource := range group.Resource {
+			for _, nodeName := range resource.Node {
+				if resource.Active {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupActive,
-						prometheus.GaugeValue, 1.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 1.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				} else {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupActive,
-						prometheus.GaugeValue, 0.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 0.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				}
-				if node.Orphaned {
+				if resource.Orphaned {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupOrphaned,
-						prometheus.GaugeValue, 1.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 1.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				} else {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupOrphaned,
-						prometheus.GaugeValue, 0.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 0.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				}
-				if node.Blocked {
+				if resource.Blocked {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupBlocked,
-						prometheus.GaugeValue, 1.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 1.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				} else {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupBlocked,
-						prometheus.GaugeValue, 0.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 0.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				}
-				if node.Managed {
+				if resource.Managed {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupManaged,
-						prometheus.GaugeValue, 1.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 1.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				} else {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupManaged,
-						prometheus.GaugeValue, 0.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 0.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				}
-				if node.Failed {
+				if resource.Failed {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupFailed,
-						prometheus.GaugeValue, 1.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 1.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				} else {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupFailed,
-						prometheus.GaugeValue, 0.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 0.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				}
-				if node.FailureIgnored {
+				if resource.FailureIgnored {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupFailureIgnored,
-						prometheus.GaugeValue, 1.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 1.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				} else {
 					ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupFailureIgnored,
-						prometheus.GaugeValue, 0.0, node.ID, group.ID,
-						nodeName.Name, node.ResourceAgent, node.Role,
-						node.TargetRole)
+						prometheus.GaugeValue, 0.0, resource.ID, group.ID,
+						nodeName.Name, resource.ResourceAgent, resource.Role,
+						resource.TargetRole)
 				}
 			}
 			ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupRunningOn,
-				prometheus.GaugeValue, node.NodesRunningOn, node.ID, group.ID,
-				node.ResourceAgent, node.Role, node.TargetRole)
+                               prometheus.GaugeValue, resource.NodesRunningOn, resource.ID, group.ID,
+                               resource.ResourceAgent, resource.Role, resource.TargetRole)
 		}
 	}
 	return nil

--- a/collector/crm_mon_linux.go
+++ b/collector/crm_mon_linux.go
@@ -53,7 +53,7 @@ func parseCrmMonXML(data []byte) (CrmMonStruct, error) {
 
 // getCrmMonInfo returns crm_mon information
 func (c *crmMonCollector) getCrmMonInfo(ch chan<- prometheus.Metric) error {
-	outBytes, err := crmMonExec("-X")
+	outBytes, err := crmMonExec("-Xr")
 	if err != nil {
 		log.Errorln(err)
 		return err
@@ -123,11 +123,11 @@ func (c *crmMonCollector) getCrmMonInfo(ch chan<- prometheus.Metric) error {
 	return nil
 }
 
-// HTMLHandler returns crm_mon -w
+// HTMLHandler returns crm_mon -wr
 func HTMLHandler(w http.ResponseWriter, r *http.Request) {
-	outBytes, err := crmMonExec("-w")
+	outBytes, err := crmMonExec("-wr")
 	if err != nil {
-		log.Warnln("Error running `crm_mon -w`", err)
+		log.Warnln("Error running `crm_mon -wr`", err)
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, err = w.Write([]byte(fmt.Sprintf("Couldn't create %s", err)))
 		if err != nil {
@@ -143,11 +143,11 @@ func HTMLHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// XMLHandler returns crm_mon -X
+// XMLHandler returns crm_mon -Xr
 func XMLHandler(w http.ResponseWriter, r *http.Request) {
-	outBytes, err := crmMonExec("-X")
+	outBytes, err := crmMonExec("-Xr")
 	if err != nil {
-		log.Warnln("Error running `crm_mon -X`", err)
+		log.Warnln("Error running `crm_mon -Xr`", err)
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, err = w.Write([]byte(fmt.Sprintf("Couldn't create %s", err)))
 		if err != nil {

--- a/collector/crm_mon_linux.go
+++ b/collector/crm_mon_linux.go
@@ -403,9 +403,6 @@ func (c *crmMonCollector) exposeResources(ch chan<- prometheus.Metric, resources
 					resource.ResourceAgent, resource.Role, resource.TargetRole)
 			}
 		}
-		ch <- prometheus.MustNewConstMetric(c.crmMonResourceRunningOn,
-                       prometheus.GaugeValue, resource.NodesRunningOn, resource.ID,
-                       resource.ResourceAgent, resource.Role, resource.TargetRole)
 	}
 	return nil
 }
@@ -484,9 +481,6 @@ func (c *crmMonCollector) exposeResourcesGroup(ch chan<- prometheus.Metric, reso
 						resource.TargetRole)
 				}
 			}
-			ch <- prometheus.MustNewConstMetric(c.crmMonResourceGroupRunningOn,
-                               prometheus.GaugeValue, resource.NodesRunningOn, resource.ID, group.ID,
-                               resource.ResourceAgent, resource.Role, resource.TargetRole)
 		}
 	}
 	return nil

--- a/collector/xmlStructs.go
+++ b/collector/xmlStructs.go
@@ -96,11 +96,11 @@ type ResourcesStruct struct {
 	} `xml:"group"`
 	Clone []struct {
 		ID             string           `xml:"id,attr"`
-		MultiState     string           `xml:"multi_state,attr"`
-		Unique         string           `xml:"unique,attr"`
-		Managed        string           `xml:"managed,attr"`
-		Failed         string           `xml:"failed,attr"`
-		FailureIgnored string           `xml:"failure_ignored,attr"`
+		MultiState     bool             `xml:"multi_state,attr"`
+		Unique         bool             `xml:"unique,attr"`
+		Managed        bool             `xml:"managed,attr"`
+		Failed         bool             `xml:"failed,attr"`
+		FailureIgnored bool             `xml:"failure_ignored,attr"`
 		Resource       []ResourceStruct `xml:"resource"`
 	} `xml:"clone"`
 }

--- a/collector/xmlStructs.go
+++ b/collector/xmlStructs.go
@@ -167,17 +167,16 @@ type BansStruct struct {
 
 // ResourceStruct struct stores the crm_mon XML resource information
 type ResourceStruct struct {
-	ID             string  `xml:"id,attr"`
-	ResourceAgent  string  `xml:"resource_agent,attr"`
-	Role           string  `xml:"role,attr"`
-	TargetRole     string  `xml:"target_role,attr"`
-	Active         bool    `xml:"active,attr"`
-	Orphaned       bool    `xml:"orphaned,attr"`
-	Blocked        bool    `xml:"blocked,attr"`
-	Managed        bool    `xml:"managed,attr"`
-	Failed         bool    `xml:"failed,attr"`
-	FailureIgnored bool    `xml:"failure_ignored,attr"`
-	NodesRunningOn float64 `xml:"nodes_running_on,attr"`
+	ID             string `xml:"id,attr"`
+	ResourceAgent  string `xml:"resource_agent,attr"`
+	Role           string `xml:"role,attr"`
+	TargetRole     string `xml:"target_role,attr"`
+	Active         bool   `xml:"active,attr"`
+	Orphaned       bool   `xml:"orphaned,attr"`
+	Blocked        bool   `xml:"blocked,attr"`
+	Managed        bool   `xml:"managed,attr"`
+	Failed         bool   `xml:"failed,attr"`
+	FailureIgnored bool   `xml:"failure_ignored,attr"`
 	Node           []struct {
 		Name   string  `xml:"name,attr"`
 		ID     float64 `xml:"id,attr"`


### PR DESCRIPTION
Only plain clones (also multi-state ones), not cloned groups of groups with clone members.

Also delete RunningOn metrics as they do not have much sense (and throw errors if used with clones).
Also ensure crm_mon lists inactive resources.